### PR TITLE
fix(frontend): cleanup Pod client on unmount

### DIFF
--- a/frontend/src/hooks/usePodClient.ts
+++ b/frontend/src/hooks/usePodClient.ts
@@ -20,6 +20,7 @@ export default function usePodClient() {
   
     return () => {
       mounted = false;
+      client.secureCleanup();
     };
   }, [client, wallet]);
 


### PR DESCRIPTION
## Summary
- invoke `client.secureCleanup()` during `useEffect` cleanup

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- `bun run lint` *(fails: code style issues found)*
- `bun run test` *(fails: missing dependencies)*

## Breaking Changes
- None

------
https://chatgpt.com/codex/tasks/task_e_68598c3a60048330a35580b5434f2be3