### PR TITLE
feat(frontend): pass env config to PodComClient

### DIFF
--- a/frontend/src/hooks/usePodClient.ts
+++ b/frontend/src/hooks/usePodClient.ts
@@ -2,12 +2,35 @@
 
 import { useAnchorWallet } from '@solana/wallet-adapter-react';
 import { useMemo, useEffect } from 'react';
-import { PodComClient } from '@pod-protocol/sdk';
+import { PodComClient, PodComConfig } from '@pod-protocol/sdk';
+import { PublicKey } from '@solana/web3.js';
 
 export default function usePodClient() {
   const wallet = useAnchorWallet();
 
-  const client = useMemo(() => new PodComClient(), []);
+  const client = useMemo(() => {
+    const config: PodComConfig = {};
+
+    if (process.env.NEXT_PUBLIC_RPC_ENDPOINT) {
+      config.endpoint = process.env.NEXT_PUBLIC_RPC_ENDPOINT;
+    }
+
+    if (process.env.NEXT_PUBLIC_PROGRAM_ID) {
+      try {
+        config.programId = new PublicKey(process.env.NEXT_PUBLIC_PROGRAM_ID);
+      } catch (err) {
+        console.warn('Invalid NEXT_PUBLIC_PROGRAM_ID', err);
+      }
+    }
+
+    if (process.env.NEXT_PUBLIC_LIGHT_RPC_URL) {
+      config.zkCompression = {
+        lightRpcUrl: process.env.NEXT_PUBLIC_LIGHT_RPC_URL,
+      };
+    }
+
+    return new PodComClient(config);
+  }, []);
 
   useEffect(() => {
     let mounted = true;


### PR DESCRIPTION
## Summary
Adds environment-based configuration for `PodComClient` in the frontend hook. The client now reads public environment variables and forwards them to the SDK.

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [x] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed

## Breaking Changes
None

------
https://chatgpt.com/codex/tasks/task_e_68598c3ca3548330bf829ffa9bdd188a