### PR TITLE
fix(sdk): clear program on reinit

### DIFF
--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -130,6 +130,17 @@ export class PodComClient {
           );
         }
 
+        // Clear any previously set program to avoid stale credentials
+        this.program = undefined;
+        this.agents.clearProgram();
+        this.messages.clearProgram();
+        this.channels.clearProgram();
+        this.escrow.clearProgram();
+        this.analytics.clearProgram();
+        this.discovery.clearProgram();
+        this.ipfs.clearProgram();
+        this.zkCompression.clearProgram();
+
         // Set IDL for all services
         this.agents.setIDL(IDL);
         this.messages.setIDL(IDL);

--- a/sdk/src/services/base.d.ts
+++ b/sdk/src/services/base.d.ts
@@ -25,6 +25,10 @@ export declare abstract class BaseService {
     protected getProgramMethods(): any;
     setProgram(program: AnchorProgram): void;
     /**
+     * Remove the program reference to avoid using stale credentials
+     */
+    clearProgram(): void;
+    /**
      * Set the IDL for read-only operations
      */
     setIDL(idl: any): void;

--- a/sdk/src/services/base.ts
+++ b/sdk/src/services/base.ts
@@ -66,6 +66,13 @@ export abstract class BaseService {
   }
 
   /**
+   * Remove the program reference to avoid using stale credentials
+   */
+  clearProgram(): void {
+    this.program = undefined;
+  }
+
+  /**
    * Set the IDL for read-only operations
    */
   setIDL(idl: any): void {


### PR DESCRIPTION
## Summary
- clear program reference if `initialize()` is called without a wallet
- remove program references in all services when reinitializing without a wallet

## ZK Compression Impact
- [ ] Uses ZK compression for cost savings
- [ ] Integrates with Light Protocol properly
- [ ] Includes Photon indexer support

## Testing
- `yarn test` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68598c3eb1588330b0c9600f55a8483e